### PR TITLE
Handled movies page transition

### DIFF
--- a/src/pages/RouterExample.js
+++ b/src/pages/RouterExample.js
@@ -106,6 +106,9 @@ export const RouterExampleRoutes = [
     hooks: {
       before: async (to, from) => {
         to.data.movies = await getMovies()
+        if (from.path === '/examples/router/tv') {
+          to.transition = PageTransitions.zoomIn
+        }
       },
     },
     transition: PageTransitions.slideInOutLeft,


### PR DESCRIPTION
while navigating to movies screen from TV route
zoomIn transition should be applied as page is keepAlive previous scale of 0.5 persists on movies view.